### PR TITLE
Don't automatically increment kills from unknown

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1020,7 +1020,8 @@ class MainMap extends React.Component {
             sendSpywareEvent({kind: 'reportHit', best: this.state.best, oldGrid: this.state.grid});
             this.onClick(...this.state.best, true);
             const {hits, misses, numericSquidsGotten} = this.getGridStatistics(this.state.grid, this.state.squidsGotten);
-            if (hits.length === 9) {
+            // This prevents users from having to input the third kill.
+            if (hits.length === 9 && numericSquidsGotten === 2) {
                 this.incrementKills();
             }
         }


### PR DESCRIPTION
Finishing a board with unknown kills would previously make it invalid, as it would be incremented to 1. We want to leave it unknown. Alternatively, we could set it to 3 specifically instead of just incrementing, which would remove the check for the previous kill count while having correct behavior. However, since unknown is not available in sequence-aware mode, and you can't reach here with less than 2 kills without majorly messing up, I wouldn't say it's worth it.