### PR TITLE
Clarify indexedDB open failure message

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,10 @@ const VERSION_STRING = 'v0.0.21';
 var globalDB = null;
 const indexedDBreq = window.indexedDB.open('splooshkaboom', 1);
 indexedDBreq.onerror = function(event) {
-    alert('Failed to access IndexedDB.');
+    alert('Could not access IndexedDB. This is usually due to using Private ' +
+          'Browsing in Firefox. The application should still work, but the ' +
+          'tables for Turbo Blurbo Mode cannot be saved and must be ' +
+          'redownloaded every time you initialize it.');
 };
 // Known issue: There's basically a race condition here in that I don't
 // wait for this onsuccess to potentially start calling dbRead.


### PR DESCRIPTION
The existing message conveyed nothing to most users, and even technical users had no way of knowing the implications of the failure. This should be much clearer since we say exactly what will not work (that they care about). Also, since `indexedDB` must have a functioning `open` method in order to get this far (which typically means it will work), we can basically assume the failure is due to Firefox's quirk of disallowing IndexedDB in Private Browsing. We will just need to adjust the message if they ever [get around to implementing it](https://bugzilla.mozilla.org/show_bug.cgi?id=1639542).